### PR TITLE
Remove mailchimp mentee tag

### DIFF
--- a/backend/api/application_form/models.py
+++ b/backend/api/application_form/models.py
@@ -1,3 +1,4 @@
+"""When people apply for ISMP, these fields are stored."""
 from datetime import date
 from hashlib import md5
 from django.conf import settings
@@ -88,7 +89,7 @@ Phone number must be entered in the format: '+999999999'. Up to 15 digits allowe
                 email_hash.hexdigest(),  # subscriber_hash
                 new_user_data)
 
-            tags_to_add = ['applied', 'mentee']
+            tags_to_add = ['applied']
             # To add a tag, you have to send a dict with the 'name': TAG_NAME and also
             # 'status':'active'. Good luck finding this in any documentation about mailchimp3.
             tag_list = [{'name': tag_name, 'status': 'active'} for tag_name in tags_to_add]

--- a/backend/api/application_form/views.py
+++ b/backend/api/application_form/views.py
@@ -49,7 +49,7 @@ class SubscribeNewsletterView(views.APIView):
 
             # due to the way the mailchimp API works, if we use create_or_update above we
             # have to set the tags for the user separately in another API call.
-            tags_to_add = ['newsletter', 'mentee']
+            tags_to_add = ['newsletter']
             # To add a tag, you have to send a dict with the 'name': TAG_NAME and also
             # 'status':'active'. Good luck finding this in any documentation about mailchimp3.
             tag_list = [{'name': tag_name, 'status': 'active'} for tag_name in tags_to_add]


### PR DESCRIPTION
Per discussion with marketing, do not add the mentee tag when adding members to mailchimp.