### PR TITLE
fix: Handle error for blog list page

### DIFF
--- a/frontend/src/pages/BlogSearchResults/BlogListPage.jsx
+++ b/frontend/src/pages/BlogSearchResults/BlogListPage.jsx
@@ -128,7 +128,7 @@ const BlogSearch = ({ term }) => {
       },
       error => {
         const errorObj = error.response;
-        setErrorMsg(`${errorObj.error}`);
+        setErrorMsg(`${errorObj ? errorObj.error : error}`);
         setIsLoading(false);
       }
     );


### PR DESCRIPTION
A quick fix for the following error
<img width="835" alt="Screen Shot 2020-06-14 at 2 05 25 PM" src="https://user-images.githubusercontent.com/43766700/84604039-1c115e00-ae48-11ea-80bc-5a989497ba95.png">