### PR TITLE
fix(footer): Make the footer stick to the bottom even if there's no content

### DIFF
--- a/frontend/src/layout/PageContainer/PageContainer.jsx
+++ b/frontend/src/layout/PageContainer/PageContainer.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import mixins from 'styles/mixins';
 
 const PageContainer = styled.div`
+  flex: 1 0 auto;
   padding-top: 64px;
   padding-bottom: 64px;
   ${mixins.responsivePadding}

--- a/frontend/src/layout/Responsive/DesktopContainer.jsx
+++ b/frontend/src/layout/Responsive/DesktopContainer.jsx
@@ -24,7 +24,11 @@ const DesktopContainer = ({ children }) => {
   };
 
   return (
-    <Responsive getWidth={getWidth} minWidth={Responsive.onlyTablet.minWidth}>
+    <Responsive
+      style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+      getWidth={getWidth}
+      minWidth={Responsive.onlyTablet.minWidth}
+    >
       <Visibility
         once={false}
         onBottomPassed={showFixedMenu}


### PR DESCRIPTION
## Proposed changes
Made the footer stick to the bottom even if there's no content
<img width="1043" alt="Screen Shot 2020-06-18 at 9 31 10 PM" src="https://user-images.githubusercontent.com/43766700/85097050-19e23300-b1ab-11ea-8660-fc7ef480a989.png">

## Types of changes

- [x] I've labeled this PR with appropriate labels (`comp/*` component, bug/feature, documentation and other less important ones).

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code._

- [x] I've linked the proper Github Issue(s) to my PR
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests (unit, integration...etc.) that prove my fix is effective or that my change works
- [x] I have added or updated necessary documentation (if appropriate). You can search, for instance using the [`silver searcher`](https://github.com/ggreer/the_silver_searcher) `ag <STRING>` to find all usages in the repository.
- [x] I have notified the team of any breaking or important changes

closes #180
