### PR TITLE
fix(blogList): Fix next page url bug in blogs page

### DIFF
--- a/frontend/src/pages/BlogSearchResults/BlogListPage.jsx
+++ b/frontend/src/pages/BlogSearchResults/BlogListPage.jsx
@@ -198,7 +198,7 @@ const BlogSearch = ({ term }) => {
       </Section>
 
       <Section>
-        {isLoading ? (
+        {isLoading || searchResults === null ? (
           <Spinner />
         ) : errorMsg ? (
           errorMessage(errorMsg)

--- a/frontend/src/pages/BlogSearchResults/BlogListPage.jsx
+++ b/frontend/src/pages/BlogSearchResults/BlogListPage.jsx
@@ -66,15 +66,15 @@ const BlogSearch = ({ term }) => {
   };
 
   // q = searchInputs (state)
-  const fetchResultResponse = (q, overridingUrl) => {
+  const fetchResultResponse = (q, nextPageUrl) => {
     setIsLoading(true);
 
     let finalFetchApiUrl = '';
 
-    if (overridingUrl) {
-      // API_ROOT is in agent.js
-      const redundantUrlFrag = API_ROOT;
-      finalFetchApiUrl = overridingUrl.replace(redundantUrlFrag, '');
+    if (nextPageUrl) {
+      const matchPage = nextPageUrl.match(/page=(.*)/);
+      const pageNumber = matchPage && matchPage[0];
+      finalFetchApiUrl = `blogpostcontent/?${pageNumber}`;
     } else {
       const urlParam = [];
       const baseApiUrl = 'blogpostcontent/';
@@ -141,7 +141,8 @@ const BlogSearch = ({ term }) => {
     return (
       <Message negative>
         <Message.Header>
-          We're sorry - there was an issue with the search request. Please try again.
+          We're sorry - there was an issue with the search request. Please try
+          again.
         </Message.Header>
         <p>{msg}</p>
       </Message>
@@ -154,9 +155,7 @@ const BlogSearch = ({ term }) => {
         <Message.Header>
           Sorry, we couldn't find any results matching "{searchInputs.query}"
         </Message.Header>
-        <p>
-          Please try another search term or try selecting a topic instead
-        </p>
+        <p>Please try another search term or try selecting a topic instead</p>
       </Message>
     );
   };
@@ -199,7 +198,7 @@ const BlogSearch = ({ term }) => {
       </Section>
 
       <Section>
-        {isLoading || searchResults === null ? (
+        {isLoading ? (
           <Spinner />
         ) : errorMsg ? (
           errorMessage(errorMsg)


### PR DESCRIPTION
## Proposed changes
This is a temporary solution to grab the next page from the `http://backend:8000/api/v1/blogpostcontent/?page=2` url. A better solution would be to have the backend send just the `page=` parameter, but not sure how much time that'll take to fix it.

![image (1)](https://user-images.githubusercontent.com/43766700/85959293-56065800-b950-11ea-9e62-b503f40a03a6.png)


## Types of changes

- [x] I've labeled this PR with appropriate labels (`comp/*` component, bug/feature, documentation and other less important ones).

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code._

- [x] I've linked the proper Github Issue(s) to my PR
closes #322 
